### PR TITLE
feat: add ReadHeader, ReadMany, and ReadManyHeaders

### DIFF
--- a/wal.go
+++ b/wal.go
@@ -977,6 +977,67 @@ func (l *Log) Sync() error {
 	return l.sfile.Sync()
 }
 
+// ReadHeader returns the first n bytes of the entry data at the given index.
+// If the entry data is shorter than n bytes, the entire data is returned.
+// If n is zero or negative, an empty slice is returned.
+// This is useful for reading fixed-size metadata headers from entries without
+// copying the full payload. The returned data is always a copy, even when the
+// NoCopy option is set, because header reads are small and the segment buffer
+// may be evicted by the LRU cache.
+func (l *Log) ReadHeader(index uint64, n int) (data []byte, err error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.corrupt {
+		return nil, ErrCorrupt
+	} else if l.closed {
+		return nil, ErrClosed
+	}
+	if n <= 0 {
+		return []byte{}, nil
+	}
+	if l.firstIndex > l.lastIndex {
+		return nil, ErrNotFound
+	}
+	if index < l.firstIndex || index > l.lastIndex {
+		return nil, ErrNotFound
+	}
+	s, err := l.loadSegment(index)
+	if err != nil {
+		return nil, err
+	}
+	epos := s.epos[index-s.index]
+	edata := s.ebuf[epos.pos:epos.end]
+	if l.opts.LogFormat == JSON {
+		// For JSON format, we must decode the full entry first
+		full, err := readJSON(edata)
+		if err != nil {
+			return nil, err
+		}
+		if n >= len(full) {
+			return full, nil
+		}
+		data = make([]byte, n)
+		copy(data, full)
+		return data, nil
+	}
+	// binary read
+	size, sn := binary.Uvarint(edata)
+	if sn <= 0 {
+		return nil, ErrCorrupt
+	}
+	if uint64(len(edata)-sn) < size {
+		return nil, ErrCorrupt
+	}
+	// Clamp n to actual data size
+	if uint64(n) > size {
+		n = int(size)
+	}
+	// Always copy — the segment buffer may be evicted by the LRU cache.
+	data = make([]byte, n)
+	copy(data, edata[sn:])
+	return data, nil
+}
+
 // IsEmpty returns true if there are no entries in the log.
 func (l *Log) IsEmpty() (bool, error) {
 	l.mu.Lock()

--- a/wal.go
+++ b/wal.go
@@ -958,6 +958,27 @@ func (l *Log) Sync() error {
 	return l.sfile.Sync()
 }
 
+// readEntryCopy is like readEntry but always copies the result, regardless of
+// the NoCopy option. This is needed for batch reads where segment eviction may
+// invalidate slices returned from earlier iterations.
+func (l *Log) readEntryCopy(s *segment, index uint64) ([]byte, error) {
+	epos := s.epos[index-s.index]
+	edata := s.ebuf[epos.pos:epos.end]
+	if l.opts.LogFormat == JSON {
+		return readJSON(edata)
+	}
+	size, n := binary.Uvarint(edata)
+	if n <= 0 {
+		return nil, ErrCorrupt
+	}
+	if uint64(len(edata)-n) < size {
+		return nil, ErrCorrupt
+	}
+	data := make([]byte, size)
+	copy(data, edata[n:])
+	return data, nil
+}
+
 // readEntry decodes a single entry from the segment buffer. Must be called
 // under at least an RLock.
 func (l *Log) readEntry(s *segment, index uint64) ([]byte, error) {
@@ -981,13 +1002,11 @@ func (l *Log) readEntry(s *segment, index uint64) ([]byte, error) {
 	return data, nil
 }
 
-// ReadMany reads entries from start to start+count-1 (inclusive) in a single
-// call, returning a slice of data for each entry. This is more efficient than
-// calling Read in a loop because it takes the lock once and reuses segment
-// lookups for consecutive entries in the same segment.
-// Entries that fall outside the log's range are not included; the returned
-// slice may be shorter than count.
-func (l *Log) ReadMany(start uint64, count int) ([][]byte, error) {
+// readMany is the shared iteration logic for ReadMany and ReadManyHeaders.
+// It takes the lock, clamps the range to valid indices, iterates with segment
+// reuse, and calls readFn for each entry.
+func (l *Log) readMany(start uint64, count int,
+	readFn func(*segment, uint64) ([]byte, error)) ([][]byte, error) {
 	l.mu.RLock()
 	defer l.mu.RUnlock()
 	if l.corrupt {
@@ -998,13 +1017,13 @@ func (l *Log) ReadMany(start uint64, count int) ([][]byte, error) {
 	if count <= 0 || l.firstIndex > l.lastIndex {
 		return nil, nil
 	}
-	// Clamp range to valid indices
 	if start < l.firstIndex {
 		start = l.firstIndex
 	}
-	end := start + uint64(count) - 1
-	if end > l.lastIndex {
-		end = l.lastIndex
+	// Clamp end to lastIndex using overflow-safe arithmetic.
+	end := l.lastIndex
+	if avail := l.lastIndex - start + 1; uint64(count) < avail {
+		end = start + uint64(count) - 1
 	}
 	if start > end {
 		return nil, nil
@@ -1012,7 +1031,6 @@ func (l *Log) ReadMany(start uint64, count int) ([][]byte, error) {
 	results := make([][]byte, 0, end-start+1)
 	var curSeg *segment
 	for i := start; i <= end; i++ {
-		// Reuse segment if the current index still belongs to it
 		if curSeg == nil || i < curSeg.index || i >= curSeg.index+uint64(len(curSeg.epos)) {
 			var err error
 			curSeg, err = l.loadSegment(i)
@@ -1020,7 +1038,7 @@ func (l *Log) ReadMany(start uint64, count int) ([][]byte, error) {
 				return nil, err
 			}
 		}
-		data, err := l.readEntry(curSeg, i)
+		data, err := readFn(curSeg, i)
 		if err != nil {
 			return nil, err
 		}
@@ -1029,49 +1047,32 @@ func (l *Log) ReadMany(start uint64, count int) ([][]byte, error) {
 	return results, nil
 }
 
+// ReadMany reads entries from start to start+count-1 (inclusive) in a single
+// call, returning a slice of data for each entry. This is more efficient than
+// calling Read in a loop because it takes the lock once and reuses segment
+// lookups for consecutive entries in the same segment.
+// Entries that fall outside the log's range are not included; the returned
+// slice may be shorter than count.
+// When the NoCopy option is set and the range spans multiple non-tail segments,
+// earlier results may reference segment buffers that are evicted from the LRU
+// cache by later segment loads. For safety, ReadMany always copies entry data
+// regardless of the NoCopy option.
+func (l *Log) ReadMany(start uint64, count int) ([][]byte, error) {
+	return l.readMany(start, count, l.readEntryCopy)
+}
+
 // ReadManyHeaders reads the first n bytes of each entry from start to
 // start+count-1 (inclusive) in a single call. This combines the efficiency
 // of ReadMany (single lock, segment reuse) with ReadHeader (partial reads).
 // Entries outside the log's range are not included; the returned slice may
 // be shorter than count.
 func (l *Log) ReadManyHeaders(start uint64, count, n int) ([][]byte, error) {
-	l.mu.RLock()
-	defer l.mu.RUnlock()
-	if l.corrupt {
-		return nil, ErrCorrupt
-	} else if l.closed {
-		return nil, ErrClosed
-	}
-	if count <= 0 || n <= 0 || l.firstIndex > l.lastIndex {
+	if n <= 0 {
 		return nil, nil
 	}
-	if start < l.firstIndex {
-		start = l.firstIndex
-	}
-	end := start + uint64(count) - 1
-	if end > l.lastIndex {
-		end = l.lastIndex
-	}
-	if start > end {
-		return nil, nil
-	}
-	results := make([][]byte, 0, end-start+1)
-	var curSeg *segment
-	for i := start; i <= end; i++ {
-		if curSeg == nil || i < curSeg.index || i >= curSeg.index+uint64(len(curSeg.epos)) {
-			var err error
-			curSeg, err = l.loadSegment(i)
-			if err != nil {
-				return nil, err
-			}
-		}
-		data, err := l.readEntryHeader(curSeg, i, n)
-		if err != nil {
-			return nil, err
-		}
-		results = append(results, data)
-	}
-	return results, nil
+	return l.readMany(start, count, func(s *segment, index uint64) ([]byte, error) {
+		return l.readEntryHeader(s, index, n)
+	})
 }
 
 // readEntryHeader decodes the first n bytes of a single entry from the segment
@@ -1108,7 +1109,7 @@ func (l *Log) readEntryHeader(s *segment, index uint64, n int) ([]byte, error) {
 
 // ReadHeader returns the first n bytes of the entry data at the given index.
 // If the entry data is shorter than n bytes, the entire data is returned.
-// If n is zero or negative, an empty slice is returned.
+// If n is zero or negative, (nil, nil) is returned.
 // This is useful for reading fixed-size metadata headers from entries without
 // copying the full payload. The returned data is always a copy, even when the
 // NoCopy option is set, because header reads are small and the segment buffer
@@ -1122,7 +1123,7 @@ func (l *Log) ReadHeader(index uint64, n int) (data []byte, err error) {
 		return nil, ErrClosed
 	}
 	if n <= 0 {
-		return []byte{}, nil
+		return nil, nil
 	}
 	if l.firstIndex > l.lastIndex {
 		return nil, ErrNotFound

--- a/wal.go
+++ b/wal.go
@@ -658,26 +658,7 @@ func (l *Log) Read(index uint64) (data []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	epos := s.epos[index-s.index]
-	edata := s.ebuf[epos.pos:epos.end]
-	if l.opts.LogFormat == JSON {
-		return readJSON(edata)
-	}
-	// binary read
-	size, n := binary.Uvarint(edata)
-	if n <= 0 {
-		return nil, ErrCorrupt
-	}
-	if uint64(len(edata)-n) < size {
-		return nil, ErrCorrupt
-	}
-	if l.opts.NoCopy {
-		data = edata[n : uint64(n)+size]
-	} else {
-		data = make([]byte, size)
-		copy(data, edata[n:])
-	}
-	return data, nil
+	return l.readEntry(s, index)
 }
 
 //go:noinline
@@ -977,6 +958,154 @@ func (l *Log) Sync() error {
 	return l.sfile.Sync()
 }
 
+// readEntry decodes a single entry from the segment buffer. Must be called
+// under at least an RLock.
+func (l *Log) readEntry(s *segment, index uint64) ([]byte, error) {
+	epos := s.epos[index-s.index]
+	edata := s.ebuf[epos.pos:epos.end]
+	if l.opts.LogFormat == JSON {
+		return readJSON(edata)
+	}
+	size, n := binary.Uvarint(edata)
+	if n <= 0 {
+		return nil, ErrCorrupt
+	}
+	if uint64(len(edata)-n) < size {
+		return nil, ErrCorrupt
+	}
+	if l.opts.NoCopy {
+		return edata[n : uint64(n)+size], nil
+	}
+	data := make([]byte, size)
+	copy(data, edata[n:])
+	return data, nil
+}
+
+// ReadMany reads entries from start to start+count-1 (inclusive) in a single
+// call, returning a slice of data for each entry. This is more efficient than
+// calling Read in a loop because it takes the lock once and reuses segment
+// lookups for consecutive entries in the same segment.
+// Entries that fall outside the log's range are not included; the returned
+// slice may be shorter than count.
+func (l *Log) ReadMany(start uint64, count int) ([][]byte, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.corrupt {
+		return nil, ErrCorrupt
+	} else if l.closed {
+		return nil, ErrClosed
+	}
+	if count <= 0 || l.firstIndex > l.lastIndex {
+		return nil, nil
+	}
+	// Clamp range to valid indices
+	if start < l.firstIndex {
+		start = l.firstIndex
+	}
+	end := start + uint64(count) - 1
+	if end > l.lastIndex {
+		end = l.lastIndex
+	}
+	if start > end {
+		return nil, nil
+	}
+	results := make([][]byte, 0, end-start+1)
+	var curSeg *segment
+	for i := start; i <= end; i++ {
+		// Reuse segment if the current index still belongs to it
+		if curSeg == nil || i < curSeg.index || i >= curSeg.index+uint64(len(curSeg.epos)) {
+			var err error
+			curSeg, err = l.loadSegment(i)
+			if err != nil {
+				return nil, err
+			}
+		}
+		data, err := l.readEntry(curSeg, i)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, data)
+	}
+	return results, nil
+}
+
+// ReadManyHeaders reads the first n bytes of each entry from start to
+// start+count-1 (inclusive) in a single call. This combines the efficiency
+// of ReadMany (single lock, segment reuse) with ReadHeader (partial reads).
+// Entries outside the log's range are not included; the returned slice may
+// be shorter than count.
+func (l *Log) ReadManyHeaders(start uint64, count, n int) ([][]byte, error) {
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	if l.corrupt {
+		return nil, ErrCorrupt
+	} else if l.closed {
+		return nil, ErrClosed
+	}
+	if count <= 0 || n <= 0 || l.firstIndex > l.lastIndex {
+		return nil, nil
+	}
+	if start < l.firstIndex {
+		start = l.firstIndex
+	}
+	end := start + uint64(count) - 1
+	if end > l.lastIndex {
+		end = l.lastIndex
+	}
+	if start > end {
+		return nil, nil
+	}
+	results := make([][]byte, 0, end-start+1)
+	var curSeg *segment
+	for i := start; i <= end; i++ {
+		if curSeg == nil || i < curSeg.index || i >= curSeg.index+uint64(len(curSeg.epos)) {
+			var err error
+			curSeg, err = l.loadSegment(i)
+			if err != nil {
+				return nil, err
+			}
+		}
+		data, err := l.readEntryHeader(curSeg, i, n)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, data)
+	}
+	return results, nil
+}
+
+// readEntryHeader decodes the first n bytes of a single entry from the segment
+// buffer. Always copies the result. Must be called under at least an RLock.
+func (l *Log) readEntryHeader(s *segment, index uint64, n int) ([]byte, error) {
+	epos := s.epos[index-s.index]
+	edata := s.ebuf[epos.pos:epos.end]
+	if l.opts.LogFormat == JSON {
+		full, err := readJSON(edata)
+		if err != nil {
+			return nil, err
+		}
+		if n >= len(full) {
+			return full, nil
+		}
+		data := make([]byte, n)
+		copy(data, full)
+		return data, nil
+	}
+	size, sn := binary.Uvarint(edata)
+	if sn <= 0 {
+		return nil, ErrCorrupt
+	}
+	if uint64(len(edata)-sn) < size {
+		return nil, ErrCorrupt
+	}
+	if uint64(n) > size {
+		n = int(size)
+	}
+	data := make([]byte, n)
+	copy(data, edata[sn:])
+	return data, nil
+}
+
 // ReadHeader returns the first n bytes of the entry data at the given index.
 // If the entry data is shorter than n bytes, the entire data is returned.
 // If n is zero or negative, an empty slice is returned.
@@ -1005,37 +1134,7 @@ func (l *Log) ReadHeader(index uint64, n int) (data []byte, err error) {
 	if err != nil {
 		return nil, err
 	}
-	epos := s.epos[index-s.index]
-	edata := s.ebuf[epos.pos:epos.end]
-	if l.opts.LogFormat == JSON {
-		// For JSON format, we must decode the full entry first
-		full, err := readJSON(edata)
-		if err != nil {
-			return nil, err
-		}
-		if n >= len(full) {
-			return full, nil
-		}
-		data = make([]byte, n)
-		copy(data, full)
-		return data, nil
-	}
-	// binary read
-	size, sn := binary.Uvarint(edata)
-	if sn <= 0 {
-		return nil, ErrCorrupt
-	}
-	if uint64(len(edata)-sn) < size {
-		return nil, ErrCorrupt
-	}
-	// Clamp n to actual data size
-	if uint64(n) > size {
-		n = int(size)
-	}
-	// Always copy — the segment buffer may be evicted by the LRU cache.
-	data = make([]byte, n)
-	copy(data, edata[sn:])
-	return data, nil
+	return l.readEntryHeader(s, index, n)
 }
 
 // IsEmpty returns true if there are no entries in the log.

--- a/wal_test.go
+++ b/wal_test.go
@@ -1494,6 +1494,29 @@ func TestReadMany(t *testing.T) {
 		}
 	})
 
+	t.Run("max-count", func(t *testing.T) {
+		l, err := Open("testlog/many-maxcount", &Options{NoSync: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		for i := uint64(1); i <= 5; i++ {
+			if err := l.Write(i, []byte(dataStr(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// math.MaxInt should not overflow — should return all 5 entries
+		results, err := l.ReadMany(1, int(^uint(0)>>1))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 5 {
+			t.Fatalf("expected 5, got %d", len(results))
+		}
+	})
+
 	t.Run("closed", func(t *testing.T) {
 		l, err := Open("testlog/many-closed", &Options{NoSync: true})
 		if err != nil {
@@ -1619,6 +1642,41 @@ func TestReadManyHeaders(t *testing.T) {
 		}
 	})
 
+	t.Run("json-format", func(t *testing.T) {
+		l, err := Open("testlog/manyh-json", &Options{
+			NoSync:      true,
+			LogFormat:   JSON,
+			SegmentSize: 256,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		for i := uint64(1); i <= 10; i++ {
+			header := []byte{byte(i), byte(i * 2)}
+			payload := []byte(fmt.Sprintf("json-payload-%d", i))
+			if err := l.Write(i, append(header, payload...)); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		results, err := l.ReadManyHeaders(1, 10, 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 10 {
+			t.Fatalf("expected 10, got %d", len(results))
+		}
+		for i, hdr := range results {
+			idx := uint64(i + 1)
+			expected := []byte{byte(idx), byte(idx * 2)}
+			if !bytes.Equal(hdr, expected) {
+				t.Fatalf("entry %d: got %v, want %v", idx, hdr, expected)
+			}
+		}
+	})
+
 	t.Run("closed", func(t *testing.T) {
 		l, err := Open("testlog/manyh-closed", &Options{NoSync: true})
 		if err != nil {
@@ -1699,8 +1757,8 @@ func TestReadHeader(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if len(data) != 0 {
-				t.Fatalf("expected 0 bytes, got %d", len(data))
+			if data != nil {
+				t.Fatalf("expected nil, got %v", data)
 			}
 
 			// ReadHeader -- not found
@@ -1763,6 +1821,19 @@ func TestReadHeader(t *testing.T) {
 		}
 		l.Close()
 		_, err = l.ReadHeader(1, 4)
+		if err != ErrClosed {
+			t.Fatalf("expected %v, got %v", ErrClosed, err)
+		}
+	})
+
+	t.Run("closed-n-zero", func(t *testing.T) {
+		l, err := Open("testlog/header-closed-nzero", &Options{NoSync: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		l.Close()
+		// n<=0 on a closed log should still return ErrClosed
+		_, err = l.ReadHeader(1, 0)
 		if err != ErrClosed {
 			t.Fatalf("expected %v, got %v", ErrClosed, err)
 		}

--- a/wal_test.go
+++ b/wal_test.go
@@ -1328,6 +1328,310 @@ func TestEmptyTruncateBackTwice(t *testing.T) {
 	}
 }
 
+func TestReadMany(t *testing.T) {
+	os.RemoveAll("testlog")
+	defer os.RemoveAll("testlog")
+
+	t.Run("basic", func(t *testing.T) {
+		l, err := Open("testlog/many-basic", &Options{
+			NoSync:      true,
+			SegmentSize: 128, // small segments to force cross-segment reads
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		for i := uint64(1); i <= 50; i++ {
+			if err := l.Write(i, []byte(dataStr(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Read all entries
+		results, err := l.ReadMany(1, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 50 {
+			t.Fatalf("expected 50, got %d", len(results))
+		}
+		for i, data := range results {
+			expected := dataStr(uint64(i + 1))
+			if string(data) != expected {
+				t.Fatalf("entry %d: got %q, want %q", i+1, data, expected)
+			}
+		}
+	})
+
+	t.Run("partial-range", func(t *testing.T) {
+		l, err := Open("testlog/many-partial", &Options{NoSync: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		for i := uint64(1); i <= 100; i++ {
+			if err := l.Write(i, []byte(dataStr(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Read middle range
+		results, err := l.ReadMany(25, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 10 {
+			t.Fatalf("expected 10, got %d", len(results))
+		}
+		for i, data := range results {
+			expected := dataStr(uint64(25 + i))
+			if string(data) != expected {
+				t.Fatalf("got %q, want %q", data, expected)
+			}
+		}
+	})
+
+	t.Run("clamp-to-bounds", func(t *testing.T) {
+		l, err := Open("testlog/many-clamp", &Options{NoSync: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		for i := uint64(1); i <= 10; i++ {
+			if err := l.Write(i, []byte(dataStr(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Request more than available
+		results, err := l.ReadMany(1, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 10 {
+			t.Fatalf("expected 10, got %d", len(results))
+		}
+
+		// Start before firstIndex
+		if err := l.TruncateFront(5); err != nil {
+			t.Fatal(err)
+		}
+		results, err = l.ReadMany(1, 100)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 6 {
+			t.Fatalf("expected 6, got %d", len(results))
+		}
+		if string(results[0]) != dataStr(5) {
+			t.Fatalf("first entry: got %q, want %q", results[0], dataStr(5))
+		}
+	})
+
+	t.Run("empty-and-zero", func(t *testing.T) {
+		l, err := Open("testlog/many-empty", &Options{
+			NoSync:     true,
+			AllowEmpty: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		// Empty log
+		results, err := l.ReadMany(1, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if results != nil {
+			t.Fatalf("expected nil, got %v", results)
+		}
+
+		// Zero count
+		if err := l.Write(1, []byte("data")); err != nil {
+			t.Fatal(err)
+		}
+		results, err = l.ReadMany(1, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if results != nil {
+			t.Fatalf("expected nil, got %v", results)
+		}
+	})
+
+	t.Run("matches-read", func(t *testing.T) {
+		l, err := Open("testlog/many-match", &Options{
+			NoSync:      true,
+			SegmentSize: 64,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		for i := uint64(1); i <= 30; i++ {
+			if err := l.Write(i, []byte(dataStr(i))); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		results, err := l.ReadMany(1, 30)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, data := range results {
+			single, err := l.Read(uint64(i + 1))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(data, single) {
+				t.Fatalf("entry %d: ReadMany != Read", i+1)
+			}
+		}
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		l, err := Open("testlog/many-closed", &Options{NoSync: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		l.Close()
+		_, err = l.ReadMany(1, 10)
+		if err != ErrClosed {
+			t.Fatalf("expected %v, got %v", ErrClosed, err)
+		}
+	})
+}
+
+func TestReadManyHeaders(t *testing.T) {
+	os.RemoveAll("testlog")
+	defer os.RemoveAll("testlog")
+
+	t.Run("basic", func(t *testing.T) {
+		l, err := Open("testlog/manyh-basic", &Options{
+			NoSync:      true,
+			SegmentSize: 128,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		for i := uint64(1); i <= 20; i++ {
+			header := []byte{byte(i), byte(i * 2)}
+			payload := make([]byte, 30) // large payload we don't want to copy
+			if err := l.Write(i, append(header, payload...)); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		results, err := l.ReadManyHeaders(1, 20, 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(results) != 20 {
+			t.Fatalf("expected 20, got %d", len(results))
+		}
+		for i, hdr := range results {
+			idx := uint64(i + 1)
+			expected := []byte{byte(idx), byte(idx * 2)}
+			if !bytes.Equal(hdr, expected) {
+				t.Fatalf("entry %d: got %v, want %v", idx, hdr, expected)
+			}
+		}
+	})
+
+	t.Run("matches-read-header", func(t *testing.T) {
+		l, err := Open("testlog/manyh-match", &Options{
+			NoSync:      true,
+			SegmentSize: 64,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		for i := uint64(1); i <= 30; i++ {
+			header := []byte{byte(i), byte(i * 3), byte(i * 5), byte(i * 7)}
+			payload := []byte(fmt.Sprintf("payload-%d", i))
+			if err := l.Write(i, append(header, payload...)); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		results, err := l.ReadManyHeaders(1, 30, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for i, hdr := range results {
+			single, err := l.ReadHeader(uint64(i+1), 4)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(hdr, single) {
+				t.Fatalf("entry %d: ReadManyHeaders != ReadHeader", i+1)
+			}
+		}
+	})
+
+	t.Run("clamp-and-empty", func(t *testing.T) {
+		l, err := Open("testlog/manyh-clamp", &Options{
+			NoSync:     true,
+			AllowEmpty: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		// Empty log
+		results, err := l.ReadManyHeaders(1, 10, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if results != nil {
+			t.Fatalf("expected nil, got %v", results)
+		}
+
+		// Zero count
+		if err := l.Write(1, []byte{1, 2, 3, 4}); err != nil {
+			t.Fatal(err)
+		}
+		results, err = l.ReadManyHeaders(1, 0, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if results != nil {
+			t.Fatalf("expected nil, got %v", results)
+		}
+
+		// Zero header size
+		results, err = l.ReadManyHeaders(1, 1, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if results != nil {
+			t.Fatalf("expected nil, got %v", results)
+		}
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		l, err := Open("testlog/manyh-closed", &Options{NoSync: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		l.Close()
+		_, err = l.ReadManyHeaders(1, 10, 4)
+		if err != ErrClosed {
+			t.Fatalf("expected %v, got %v", ErrClosed, err)
+		}
+	})
+}
+
 func TestReadHeader(t *testing.T) {
 	os.RemoveAll("testlog")
 	defer os.RemoveAll("testlog")

--- a/wal_test.go
+++ b/wal_test.go
@@ -1,6 +1,7 @@
 package wal
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -1325,6 +1326,187 @@ func TestEmptyTruncateBackTwice(t *testing.T) {
 	if !empty {
 		t.Fatalf("expected %v, got %v", true, empty)
 	}
+}
+
+func TestReadHeader(t *testing.T) {
+	os.RemoveAll("testlog")
+	defer os.RemoveAll("testlog")
+
+	for _, format := range []struct {
+		name string
+		fmt  LogFormat
+	}{
+		{"binary", Binary},
+		{"json", JSON},
+	} {
+		t.Run(format.name, func(t *testing.T) {
+			logPath := "testlog/header-" + format.name
+			l, err := Open(logPath, &Options{
+				NoSync:    true,
+				LogFormat: format.fmt,
+				NoCopy:    false,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer l.Close()
+
+			// Write entries with known headers:
+			// 4-byte header prefix + payload
+			for i := uint64(1); i <= 10; i++ {
+				header := []byte{byte(i), byte(i * 2), byte(i * 3), byte(i * 4)}
+				payload := []byte(fmt.Sprintf("payload-for-entry-%d-with-extra-data", i))
+				entry := append(header, payload...)
+				if err := l.Write(i, entry); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// ReadHeader -- read 4-byte header from each entry
+			for i := uint64(1); i <= 10; i++ {
+				header, err := l.ReadHeader(i, 4)
+				if err != nil {
+					t.Fatalf("ReadHeader(%d, 4): %v", i, err)
+				}
+				expected := []byte{byte(i), byte(i * 2), byte(i * 3), byte(i * 4)}
+				if !bytes.Equal(header, expected) {
+					t.Fatalf("entry %d: header = %v, want %v", i, header, expected)
+				}
+			}
+
+			// ReadHeader -- request more bytes than entry has
+			short := []byte{1, 2}
+			if err := l.Write(11, short); err != nil {
+				t.Fatal(err)
+			}
+			data, err := l.ReadHeader(11, 100)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(data) != 2 {
+				t.Fatalf("expected 2 bytes, got %d", len(data))
+			}
+			if data[0] != 1 || data[1] != 2 {
+				t.Fatalf("expected [1 2], got %v", data)
+			}
+
+			// ReadHeader -- request 0 bytes
+			data, err = l.ReadHeader(1, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(data) != 0 {
+				t.Fatalf("expected 0 bytes, got %d", len(data))
+			}
+
+			// ReadHeader -- not found
+			_, err = l.ReadHeader(999, 4)
+			if err != ErrNotFound {
+				t.Fatalf("expected %v, got %v", ErrNotFound, err)
+			}
+
+			// ReadHeader -- verify it matches full Read
+			for i := uint64(1); i <= 10; i++ {
+				full, err := l.Read(i)
+				if err != nil {
+					t.Fatal(err)
+				}
+				header, err := l.ReadHeader(i, 4)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if !bytes.Equal(header, full[:len(header)]) {
+					t.Fatalf("entry %d: ReadHeader = %v, want %v",
+						i, header, full[:len(header)])
+				}
+			}
+		})
+	}
+
+	t.Run("nocopy", func(t *testing.T) {
+		logPath := "testlog/header-nocopy"
+		l, err := Open(logPath, &Options{
+			NoSync: true,
+			NoCopy: true,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		entry := []byte{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+		if err := l.Write(1, entry); err != nil {
+			t.Fatal(err)
+		}
+
+		header, err := l.ReadHeader(1, 4)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(header) != 4 {
+			t.Fatalf("expected 4 bytes, got %d", len(header))
+		}
+		expected := []byte{0xAA, 0xBB, 0xCC, 0xDD}
+		if !bytes.Equal(header, expected) {
+			t.Fatalf("header = %v, want %v", header, expected)
+		}
+	})
+
+	t.Run("closed", func(t *testing.T) {
+		l, err := Open("testlog/header-closed", &Options{NoSync: true})
+		if err != nil {
+			t.Fatal(err)
+		}
+		l.Close()
+		_, err = l.ReadHeader(1, 4)
+		if err != ErrClosed {
+			t.Fatalf("expected %v, got %v", ErrClosed, err)
+		}
+	})
+
+	t.Run("after-truncate", func(t *testing.T) {
+		logPath := "testlog/header-truncate"
+		l, err := Open(logPath, &Options{
+			NoSync:      true,
+			SegmentSize: 128, // small segments to test cross-segment reads
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer l.Close()
+
+		// Write entries across multiple segments
+		for i := uint64(1); i <= 50; i++ {
+			header := []byte{byte(i), byte(i)}
+			payload := make([]byte, 20)
+			entry := append(header, payload...)
+			if err := l.Write(i, entry); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// Truncate front
+		if err := l.TruncateFront(25); err != nil {
+			t.Fatal(err)
+		}
+
+		// Should be able to read headers of remaining entries
+		for i := uint64(25); i <= 50; i++ {
+			header, err := l.ReadHeader(i, 2)
+			if err != nil {
+				t.Fatalf("ReadHeader(%d, 2) after truncate: %v", i, err)
+			}
+			if header[0] != byte(i) || header[1] != byte(i) {
+				t.Fatalf("entry %d: expected [%d %d], got %v", i, i, i, header)
+			}
+		}
+
+		// Truncated entries should not be found
+		_, err = l.ReadHeader(1, 2)
+		if err != ErrNotFound {
+			t.Fatalf("expected %v, got %v", ErrNotFound, err)
+		}
+	})
 }
 
 func TestIssue33(t *testing.T) {


### PR DESCRIPTION
## Summary

New methods for efficient partial and batch reads from the WAL.

**`ReadHeader(index, n)`** — read the first `n` bytes of an entry without copying the full payload. Useful for inspecting embedded metadata headers (retry counts, item counts, etc.) without deserializing the full entry.

**`ReadMany(start, count)`** — batch read a contiguous range of entries, returning `[][]byte`. Reuses loaded segments across the range instead of calling `loadSegment` per entry.

**`ReadManyHeaders(start, count, n)`** — batch read the first `n` bytes of each entry in a range. Combines the efficiency of `ReadHeader` with the segment reuse of `ReadMany`.

## Design

- `ReadHeader` always copies the result even with `NoCopy` — the segment buffer can be evicted by the LRU cache between calls.
- `ReadMany` and `ReadManyHeaders` track the current segment and only call `loadSegment` when crossing segment boundaries.
- Internal helpers `readEntry` and `readEntryHeader` are extracted from `Read`/`ReadHeader` and shared by the batch methods.
- `Read` is refactored to use `readEntry`.
- All methods use `RLock`, consistent with existing read paths.
- Ranges are clamped to `[FirstIndex, LastIndex]` — out-of-bounds requests return partial results rather than errors.